### PR TITLE
Add missing stack markings (non executable)

### DIFF
--- a/architecture.S
+++ b/architecture.S
@@ -42,3 +42,7 @@ architecture:
         mov     a1, #7
         bx      lr
 .endfunc
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif


### PR DESCRIPTION
When playing with a default raspbian, @diouziou and I noticed that every stack, no matter if compiled with NX or not, is marked as executable.

    ➜  ~ cat /proc/self/maps
    00010000-00019000 r-xp 00000000 b3:02 524        /bin/cat
    00028000-00029000 r--p 00008000 b3:02 524        /bin/cat
    00029000-0002a000 rw-p 00009000 b3:02 524        /bin/cat
    00b8f000-00bb0000 rw-p 00000000 00:00 0          [heap]
    76ac4000-76ae6000 rw-p 00000000 00:00 0 
    76ae6000-76c17000 r--p 001c7000 b3:02 234        /usr/lib/locale/locale-archive
    76c17000-76e17000 r--p 00000000 b3:02 234        /usr/lib/locale/locale-archive
    76e17000-76f42000 r-xp 00000000 b3:02 1946       /lib/arm-linux-gnueabihf/libc-2.19.so
    76f42000-76f52000 ---p 0012b000 b3:02 1946       /lib/arm-linux-gnueabihf/libc-2.19.so
    76f52000-76f54000 r--p 0012b000 b3:02 1946       /lib/arm-linux-gnueabihf/libc-2.19.so
    76f54000-76f55000 rw-p 0012d000 b3:02 1946       /lib/arm-linux-gnueabihf/libc-2.19.so
    76f55000-76f58000 rw-p 00000000 00:00 0 
    76f58000-76f5d000 r-xp 00000000 b3:02 10212      /usr/lib/arm-linux-gnueabihf/libarmmem.so
    76f5d000-76f6c000 ---p 00005000 b3:02 10212      /usr/lib/arm-linux-gnueabihf/libarmmem.so
    76f6c000-76f6d000 rw-p 00004000 b3:02 10212      /usr/lib/arm-linux-gnueabihf/libarmmem.so
    76f6d000-76f8d000 r-xp 00000000 b3:02 1914       /lib/arm-linux-gnueabihf/ld-2.19.so
    76f91000-76f93000 rw-p 00000000 00:00 0 
    76f9a000-76f9c000 rw-p 00000000 00:00 0 
    76f9c000-76f9d000 r--p 0001f000 b3:02 1914       /lib/arm-linux-gnueabihf/ld-2.19.so
    76f9d000-76f9e000 rw-p 00020000 b3:02 1914       /lib/arm-linux-gnueabihf/ld-2.19.so
    7ef24000-7ef45000 rwxp 00000000 00:00 0          [stack]
    7eff4000-7eff5000 r-xp 00000000 00:00 0          [sigpage]
    7eff5000-7eff6000 r--p 00000000 00:00 0          [vvar]
    7eff6000-7eff7000 r-xp 00000000 00:00 0          [vdso]
    ffff0000-ffff1000 r-xp 00000000 00:00 0          [vectors]

    $ readelf -a /bin/cat | grep STACK
    GNU_STACK      0x000000 0x00000000 0x00000000 0x00000 0x00000 RW  0x10

This is the same problem as with the old libcofi_rpi, where some stack markings where [missing](https://github.com/simonjhall/copies-and-fills/commit/2a0cfc336eb61baa61a12ebc2bd122d202d95aa7). The ASM lines to fix this are added to nearly all files in this lib, but not in architecture.S.

    $ scanelf -e libarmmem.so 
     TYPE   STK/REL/PTL FILE 
    ET_DYN RWX --- RW- libarmmem.so

This is for example responsible for nearly all binaries in raspbian to ignore NX. The fix will ensure that the correct stack markings are set.

    $ scanelf -e libarmmem.so
     TYPE   STK/REL/PTL FILE 
    ET_DYN RW- --- RW- libarmmem.so 
