### PR TITLE
Add function type and sizes.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,13 +11,13 @@ all: libarmmem-v6l.so libarmmem-v6l.a libarmmem-v7l.so libarmmem-v7l.a test test
 	$(CROSS_COMPILE)gcc -c -o $@ $^
 
 libarmmem-v6l.so: $(OBJS-V6L)
-	$(CROSS_COMPILE)gcc -shared -o $@ $^
+	$(CROSS_COMPILE)gcc -shared -o $@ -Wl,-soname,$@ $^
 
 libarmmem-v6l.a: $(OBJS-V6L)
 	$(CROSS_COMPILE)ar rcs $@ $^
 
 libarmmem-v7l.so: $(OBJS-V7L)
-	$(CROSS_COMPILE)gcc -shared -o $@ $^
+	$(CROSS_COMPILE)gcc -shared -o $@ -Wl,-soname,$@ $^
 
 libarmmem-v7l.a: $(OBJS-V7L)
 	$(CROSS_COMPILE)ar rcs $@ $^

--- a/arm-mem.h
+++ b/arm-mem.h
@@ -29,6 +29,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 .macro myfunc fname
  .func fname
  .global fname
+ .type fname STT_FUNC
 fname:
 .endm
 

--- a/memcmp-v6l.S
+++ b/memcmp-v6l.S
@@ -278,6 +278,7 @@ myfunc memcmp
         movhi   a1, #1
         movlo   a1, #-1
         pop     {DAT1-DAT6, pc}
+        .size memcmp,.-memcmp
 
         .unreq  S_1
         .unreq  S_2

--- a/memcmp-v7l.S
+++ b/memcmp-v7l.S
@@ -457,3 +457,4 @@ myfunc memcmp
 43:     vpop        {q4}
         mov         RES, #0
         pop         {v1-v3,pc}
+        .size memcmp,.-memcmp

--- a/memcpymove-v6l.S
+++ b/memcpymove-v6l.S
@@ -533,6 +533,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 myfunc memcpy
 1000:   memcpy  0
+        .size memcpy,.-memcpy
 .endfunc
 
 /*
@@ -551,6 +552,7 @@ myfunc memmove
         cmp     a2, a1
         bpl     1000b   /* pl works even over -1 - 0 and 0x7fffffff - 0x80000000 boundaries */
         memcpy  1
+        .size memmove,.-memmove
 .endfunc
 
 /*
@@ -565,9 +567,12 @@ myfunc memmove
 
 myfunc mempcpy
 .global __mempcpy
+.type __mempcpy STT_FUNC
 __mempcpy:
         push    {v1, lr}
         mov     v1, a3
         bl      1000b
         add     a1, a1, v1
         pop     {v1, pc}
+	.size mempcpy,.-mempcpy
+	.size __mempcpy,.-__mempcpy

--- a/memcpymove-v7l.S
+++ b/memcpymove-v7l.S
@@ -614,6 +614,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 myfunc memcpy
 1000:   memcpy  0
+        .size memcpy,.-memcpy
 .endfunc
 
 /*
@@ -632,6 +633,7 @@ myfunc memmove
         cmp     a2, a1
         bpl     1000b   /* pl works even over -1 - 0 and 0x7fffffff - 0x80000000 boundaries */
         memcpy  1
+        .size memmove,.-memmove
 .endfunc
 
 /*
@@ -646,9 +648,12 @@ myfunc memmove
 
 myfunc mempcpy
 .global __mempcpy
+.type __mempcpy STT_FUNC
 __mempcpy:
         push    {v1, lr}
         mov     v1, a3
         bl      1000b
         add     a1, a1, v1
         pop     {v1, pc}
+        .size mempcpy,.-mempcpy
+        .size __mempcpy,.-__mempcpy

--- a/memset-v6l.S
+++ b/memset-v6l.S
@@ -111,6 +111,7 @@ myfunc memset
 174:    tst     N, #16
         stmneia S!, {DAT0, DAT1, DAT2, DAT3}
         b       166b
+        .size memset,.-memset
 
         .unreq  S
         .unreq  DAT0

--- a/memset-v7l.S
+++ b/memset-v7l.S
@@ -111,6 +111,7 @@ myfunc memset
         vst1.8  {q0-q1}, [SI]!
         sub     N, N, #32
         b       166b
+        .size memset,.-memset
 
         .unreq  SJ
         .unreq  N

--- a/strlen-v7l.S
+++ b/strlen-v7l.S
@@ -154,3 +154,4 @@ myfunc strlen
         sub         a1, #4
         add         a1, TMP3, lsr #3
         pop         {v1,pc}
+        .size strlen,.-strlen


### PR DESCRIPTION
For GitHub issue #11 Valgrind cannot redirect libarmmem symbols